### PR TITLE
Slightly rework Timestamped trait to allow overriding core methods

### DIFF
--- a/src/Entity/Timestamped.php
+++ b/src/Entity/Timestamped.php
@@ -6,8 +6,24 @@ use DateTime;
 
 trait Timestamped {
 
-    public static function getDateTimeColumns(): array {
-        $columns = parent::getDateTimeColumns();
+    public function __construct() {
+        parent::__construct();
+
+        $this->addTimestampColumns();
+    }
+
+    protected function addTimestampColumns(): void {
+        if (!isset(static::$hasCreatedAt) || static::$hasCreatedAt) {
+            $this->setValue("created_at", null);
+        }
+
+        if (!isset(static::$hasUpdatedAt) || static::$hasUpdatedAt) {
+            $this->setValue("updated_at", null);
+        }
+    }
+
+    protected static function getTimestampColumns(): array {
+        $columns = [];
 
         if (!isset(static::$hasCreatedAt) || static::$hasCreatedAt) {
             $columns[] = "created_at";
@@ -20,19 +36,11 @@ trait Timestamped {
         return $columns;
     }
 
-    public function __construct() {
-        parent::__construct();
-
-        if (!isset(static::$hasCreatedAt) || static::$hasCreatedAt) {
-            $this->setValue("created_at", null);
-        }
-
-        if (!isset(static::$hasUpdatedAt) || static::$hasUpdatedAt) {
-            $this->setValue("updated_at", null);
-        }
+    public static function getDateTimeColumns(): array {
+        return array_merge(parent::getDateTimeColumns(), static::getTimestampColumns());
     }
 
-    public function save(): bool {
+    protected function setTimestamps(): void {
         $isNew = !$this->isLoaded();
 
         if ($isNew && (!isset(static::$hasCreatedAt) || static::$hasCreatedAt)) {
@@ -42,6 +50,10 @@ trait Timestamped {
         if (!isset(static::$hasUpdatedAt) || static::$hasUpdatedAt) {
             $this->setValue("updated_at", new DateTime());
         }
+    }
+
+    public function save(): bool {
+        $this->setTimestamps();
 
         return parent::save();
     }


### PR DESCRIPTION
Add new local methods to Timestamped trait so any class that uses can overwrite the core jpi/orm methods and call these manually.