### PR TITLE
Remove base path on router

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -47,8 +47,6 @@ class Core {
     private function initRoutes(): void {
         $router = $this->router;
 
-        $router->setBasePath("/v" . static::VERSION . "/");
-
         $projectsController = ProjectsController::class;
         $authController = Auth::class;
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -19,18 +19,8 @@ class Router {
 
     use Responder;
 
-    protected $basePath = "";
-
     protected $routes = [];
     protected $namedRoutes = [];
-
-    public function setBasePath(string $basePath): void {
-        $this->basePath = $basePath;
-    }
-
-    public function getBasePath(): string {
-        return $this->basePath;
-    }
 
     /**
      * @param $path string
@@ -61,12 +51,7 @@ class Router {
     }
 
     protected function getFullPath(string $path): string {
-        $basePath = $this->getBasePath();
-        if ($basePath !== "") {
-            $path = URL::addTrailingSlash($basePath) . URL::removeLeadingSlash($path);
-        }
-
-        return $path;
+        return "/v" . Core::VERSION . "/"  . URL::removeLeadingSlash($path);
     }
 
     /**


### PR DESCRIPTION
The router is already aware the first part of the URI is the version, so unnecessary to have a "base" too, which is the version too.