### PR TITLE
Handle purposely blanking columns

### DIFF
--- a/src/Entity/API/CrudService.php
+++ b/src/Entity/API/CrudService.php
@@ -108,15 +108,21 @@ class CrudService {
         foreach ($entity::getColumns() as $column) {
             $label = Str::machineToDisplay($column);
 
-            if (empty($data[$column])) {
-                if (in_array($column, $requiredColumns)) {
-                    $errors[$column] = "$label is required.";
-                }
-
+            if (!isset($data[$column])) {
                 continue;
             }
 
             $value = $data[$column];
+
+            if (empty($value)) {
+                if (in_array($column, $requiredColumns)) {
+                    $errors[$column] = "$label is required.";
+                } else {
+                    $entity->$column = $value;
+                }
+
+                continue;
+            }
 
             if (in_array($column, $intColumns)) {
                 if (is_numeric($value) && $value == (int)$value) {


### PR DESCRIPTION
Allow updating entity with blank value if column isn't a required column.
Also don't force having all columns in request.